### PR TITLE
Add avogadro-ibo: Intrinsic Bond Orbital (IBO/IAO) computation via Psi4

### DIFF
--- a/repositories.toml
+++ b/repositories.toml
@@ -137,3 +137,8 @@ git.commit = "e933ae40dbe1d5d5e3a76cac36eed69b6d430766"
 [molfidget]
 git.repo = "https://github.com/ghutchis/avogadro-molfidget"
 git.commit = "7801a56b0fde2c63cd5a2512a1004fa1cb4b866b"
+
+[ibo]
+git.repo = "https://github.com/exergonic/avo_ibo.git"
+git.commit = "d6dcd70a60f257e93eec9f564e3e19bb1381acbe"
+release-tag = "v0.4.0"


### PR DESCRIPTION
Compute IAOs/IBOs from Avogadro 2 using Psi4 as the backend. Produces localized bond orbitals for occupied and virtual blocks with on-atom Fock-resolved degeneracies, Molden output for isosurface viewing, and a full analysis table (occupancy, energy, bond type, composition, hybridization).

Closed-shell only; configurable method/basis (defaults: hf/cc-pVDZ). Elements through I (Z=53), including 3d transition metals.