### PR TITLE
Update xtb plugin to 0.11.2

### DIFF
--- a/repositories.toml
+++ b/repositories.toml
@@ -66,8 +66,8 @@ git.commit = "2c3c72f2b97fc0231c2628a221c3dc519166c422"
 
 [xtb]
 git.repo = "https://github.com/matterhorn103/avo_xtb.git"
-git.commit = "425500143b5a795dcd26983f5abb4183e905ff41"
-release-tag = "0.11.1"
+git.commit = "e77e1d57faa5558acc36972dc0020f13ad6732b3"
+release-tag = "0.11.2"
 
 [xtb-energy]
 git.repo = "https://github.com/ghutchis/avogadro-xtb-energy.git"


### PR DESCRIPTION
This patch adds a setup script to fix use of the plugin on Windows in combination with Pixi.