### PR TITLE
Add a CloudFlare worker (coded by Claude Code Opus 5.0)

### DIFF
--- a/scripts/generate_index.py
+++ b/scripts/generate_index.py
@@ -14,6 +14,7 @@ import shutil
 import tempfile
 import tomllib
 import traceback
+import urllib.error
 import urllib.request
 from pathlib import Path
 
@@ -27,6 +28,12 @@ PLUGIN_TYPES = [
     "pypkg",
 ]
 
+"""Base URL of the download counter that plugin downloads are routed through.
+
+GitHub reports no download count for the auto-generated source archives, so
+installs are counted by a redirect hop in front of them. See `worker/`."""
+DEFAULT_WORKER = "https://plugins.avogadro.cc"
+
 """A list of current plugin feature types."""
 FEATURE_TYPES = [
     "electrostatic-models",
@@ -37,9 +44,104 @@ FEATURE_TYPES = [
 ]
 
 
+"""User agent for this script's own HTTP requests.
+
+Cloudflare answers the default `Python-urllib/...` agent with a 403, which would
+silently disable the download counter and fall the index back to GitHub URLs on
+every build."""
+USER_AGENT = "avogadro-plugin-index/1.0 (+https://github.com/Avogadro/plugins)"
+
+
+def request(url: str, method: str = "GET") -> urllib.request.Request:
+    """Build a request that identifies itself."""
+    return urllib.request.Request(
+        url, method=method, headers={"User-Agent": USER_AGENT}
+    )
+
+
 def normalize_pkg_name(name: str) -> str:
     """Normalize a package name as per PEP 503."""
     return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def check_download_url(download_url: str, expected_target: str):
+    """Confirm the download counter resolves a plugin to the expected archive.
+
+    Uses HEAD, which the Worker deliberately does not count, so validating the
+    index costs nothing in the download statistics. Catches the case where the
+    Worker cannot resolve a plugin whose repository name differs from its
+    plugin name."""
+
+    class NoRedirect(urllib.request.HTTPRedirectHandler):
+        def redirect_request(self, req, fp, code, msg, headers, newurl):
+            return None
+
+    opener = urllib.request.build_opener(NoRedirect)
+    try:
+        with opener.open(request(download_url, "HEAD")) as response:
+            raise Exception(
+                f"{download_url} returned {response.status}, expected a redirect!"
+            )
+    except urllib.error.HTTPError as e:
+        if e.code not in (301, 302, 307, 308):
+            raise Exception(f"{download_url} returned {e.code}!")
+        target = e.headers.get("Location")
+        if target != expected_target:
+            raise Exception(
+                f"{download_url} redirects to {target}, expected {expected_target}!"
+            )
+
+
+def worker_available(worker: str) -> bool:
+    """Check the download counter is reachable before relying on it.
+
+    Without this, an outage would make every plugin fail its URL check and drop
+    out of the generated index. Losing the download statistics for one build is
+    an acceptable failure; publishing an empty index is not."""
+    try:
+        with urllib.request.urlopen(request(f"{worker}/health"), timeout=10) as r:
+            if r.status == 200:
+                return True
+            print(f"{worker} returned {r.status} rather than 200")
+    except Exception as e:
+        print(f"Could not reach {worker}: {e}")
+    return False
+
+
+def fetch_download_counts(stats_url: str) -> dict:
+    """Fetch per-plugin download counts from the download counter.
+
+    Returns an empty dict on any failure: statistics are a nice-to-have, and
+    must never stop the index from being generated."""
+    try:
+        with urllib.request.urlopen(request(stats_url), timeout=30) as response:
+            stats = json.load(response)
+    except Exception as e:
+        print(f"Could not fetch download counts from {stats_url}: {e}")
+        return {}
+
+    window = stats.get("window_days")
+    counts = {}
+    for plugin, entry in stats.get("plugins", {}).items():
+        counts[plugin] = {
+            "total": entry.get("total", 0),
+            "recent": entry.get("recent", 0),
+            "window-days": window,
+        }
+    print(f"Fetched download counts for {len(counts)} plugins")
+    return counts
+
+
+def add_download_counts(all_metadata: list[dict], counts: dict):
+    """Merge download counts into the generated metadata.
+
+    A plugin with no counter entry gets zeroes rather than a missing key, so
+    that consumers do not have to special-case a newly added plugin."""
+    for metadata in all_metadata:
+        short_name = metadata["name"].removeprefix("avogadro-")
+        metadata["downloads"] = counts.get(
+            short_name, {"total": 0, "recent": 0, "window-days": None}
+        )
 
 
 def get_gh_repo_metadata(gh_repo, commit: str, release_tag: str | None) -> dict:
@@ -281,7 +383,9 @@ def set_defaults(repo_info: dict):
         repo_info.setdefault(k, v)
 
 
-def get_metadata(table_name: str, repo_info: dict, gh: Github) -> dict:
+def get_metadata(
+    table_name: str, repo_info: dict, gh: Github, worker: str | None, strict: bool
+) -> dict:
     """Get and validate the metadata for a single plugin based on the provided
     information."""
     # First add the default values for any optional keys
@@ -309,11 +413,30 @@ def get_metadata(table_name: str, repo_info: dict, gh: Github) -> dict:
         gh_repo = gh.get_repo(repo_name)
 
         # Automatically generate the source archive details for Avogadro
-        src_url = f"{repo_url}/archive/{commit}.zip"
+        # Always hash the archive straight from GitHub, so that generating the
+        # index does not depend on the download counter being up
+        archive_url = f"{repo_url}/archive/{commit}.zip"
         src_hash = hashlib.sha256()
-        with urllib.request.urlopen(src_url) as response:
+        with urllib.request.urlopen(request(archive_url)) as response:
             while chunk := response.read(8192):
                 src_hash.update(chunk)
+
+        # Hand Avogadro the counted URL instead, which redirects to exactly the
+        # archive hashed above, so the recorded hash still validates
+        src_url = archive_url
+        if worker:
+            counted_url = f"{worker}/dl/{table_name}/{commit}.zip"
+            try:
+                check_download_url(counted_url, archive_url)
+                src_url = counted_url
+            except Exception as e:
+                # An uncounted install beats a broken one, so fall back to the
+                # archive URL rather than dropping the plugin from the index
+                print(f"WARNING: {e}")
+                print(f"Falling back to the GitHub archive URL for {table_name}")
+                if strict:
+                    raise
+
         repo_info["src"] = {"url": src_url, "sha256": src_hash.hexdigest()}
 
         path = repo_info.get("path", ".")
@@ -374,7 +497,9 @@ def get_metadata(table_name: str, repo_info: dict, gh: Github) -> dict:
     return plugin_metadata
 
 
-def get_metadata_all(repos: dict[str, dict], gh: Github, strict: bool) -> list[dict]:
+def get_metadata_all(
+    repos: dict[str, dict], gh: Github, strict: bool, worker: str | None
+) -> list[dict]:
     """Collect all the metadata for all plugins with repository information in
     the provided dict."""
     all_metadata = []
@@ -382,7 +507,7 @@ def get_metadata_all(repos: dict[str, dict], gh: Github, strict: bool) -> list[d
     for table_name, repo_info in repos.items():
         print("----------" * 8)
         try:
-            plugin_metadata = get_metadata(table_name, repo_info, gh)
+            plugin_metadata = get_metadata(table_name, repo_info, gh, worker, strict)
             all_metadata.append(plugin_metadata)
             print(f"Metadata OK, {table_name} added to generated plugin index")
         except Exception as e:
@@ -418,6 +543,19 @@ if __name__ == "__main__":
         help="Fetch and validate the metadata for only the given plugins",
     )
     parser.add_argument(
+        "--worker",
+        default=DEFAULT_WORKER,
+        help=(
+            "Base URL of the download counter, which the source URLs are routed"
+            f" through (default: {DEFAULT_WORKER})"
+        ),
+    )
+    parser.add_argument(
+        "--no-worker",
+        action="store_true",
+        help="Point source URLs straight at GitHub and omit download counts",
+    )
+    parser.add_argument(
         "repos_file",
         nargs="?",
         default=Path(__file__).with_name("repositories.toml"),
@@ -425,6 +563,11 @@ if __name__ == "__main__":
         help="Path to repositories.toml (default: next to this script)",
     )
     args = parser.parse_args()
+
+    worker = None if args.no_worker else args.worker.rstrip("/")
+    if worker and not worker_available(worker):
+        print("Continuing with GitHub archive URLs and no download counts")
+        worker = None
 
     auth = Auth.Token(args.token) if args.token else None
 
@@ -435,7 +578,9 @@ if __name__ == "__main__":
         repos = tomllib.load(f)
     if args.plugins:
         repos = {k: v for k, v in repos.items() if k in args.plugins}
-    metadata = get_metadata_all(repos, gh, args.strict)
+    metadata = get_metadata_all(repos, gh, args.strict, worker)
+    if worker:
+        add_download_counts(metadata, fetch_download_counts(f"{worker}/stats"))
     indent = 2 if args.pretty else None
     if args.show:
         print(json.dumps(metadata, indent=indent))

--- a/scripts/generate_index.py
+++ b/scripts/generate_index.py
@@ -138,7 +138,9 @@ def add_download_counts(all_metadata: list[dict], counts: dict):
     A plugin with no counter entry gets zeroes rather than a missing key, so
     that consumers do not have to special-case a newly added plugin."""
     for metadata in all_metadata:
-        short_name = metadata["name"].removeprefix("avogadro-")
+        # Match the canonical form the counter records under, which is
+        # normalized as per PEP 503. Plugin names may contain capitals
+        short_name = normalize_pkg_name(metadata["name"]).removeprefix("avogadro-")
         metadata["downloads"] = counts.get(
             short_name, {"total": 0, "recent": 0, "window-days": None}
         )

--- a/worker/.gitignore
+++ b/worker/.gitignore
@@ -1,0 +1,14 @@
+# Wrangler's local state: build cache, temp files, and the local D1 database
+# used by `wrangler dev`. Regenerated on demand, and unrelated to production.
+.wrangler/
+
+# Local secret vars for `wrangler dev`. Never commit these.
+.dev.vars
+.dev.vars.*
+
+node_modules/
+
+# schema.sql is the table definition and must be committed. A global ignore of
+# `*.sql` is common enough to be worth overriding here; a .gitignore nearer the
+# file wins over the global one.
+!schema.sql

--- a/worker/README.md
+++ b/worker/README.md
@@ -1,0 +1,224 @@
+# Plugin download counter
+
+A Cloudflare Worker that counts plugin installs. GitHub does not report download
+counts for auto-generated source archives (`/archive/<ref>.zip`), and the traffic
+API needs push access to each repository, so the only way to measure installs is
+to count them ourselves.
+
+The Worker sits in front of the GitHub archive URL as a redirect hop:
+
+```
+Avogadro -> https://plugins.avogadro.cc/dl/aimnet2/<ref>.zip   (counted, 302)
+         -> https://github.com/ghutchis/avogadro-aimnet2/archive/<ref>.zip
+         -> https://codeload.github.com/...                    (GitHub's own hop)
+```
+
+The archive bytes are untouched, so the `sha256` already recorded in
+`plugins2.json` still validates. Avogadro's package manager follows the hop with
+no client change: `packagemanagerdialog.cpp` sets `NoLessSafeRedirectPolicy` and
+handles 301/302/307/308 explicitly.
+
+## Routes
+
+| Route | Purpose |
+|-------|---------|
+| `GET /dl/<plugin>/<ref>.zip` | Count the request, 302 to the GitHub archive |
+| `GET /stats` | Per-plugin `total` and `recent` counts |
+| `GET /stats/<plugin>` | One plugin, plus a daily series |
+| `GET /health` | Liveness probe |
+
+`/stats` accepts `?days=` (default 30) and `?client=avogadro\|bot\|other\|all`
+(default `avogadro`).
+
+### Plugin names
+
+The index generator guarantees every plugin `name` is `avogadro-<something>`,
+but the **repository** name need not match: `avogadro-xtb` lives in `avo_xtb`,
+`avogadro-ibo` in `avo_ibo`, `avogadro-generators` in `avogenerators`.
+
+So a plugin is accepted under its plugin name, its repo name, and either with a
+leading `avogadro-` or `avo-` removed. Names are compared PEP 503-style, with
+`-`, `_` and `.` treated alike, so `avo_xtb` and `avo-xtb` are the same thing.
+All of these reach the same plugin and count into the same bucket:
+
+```
+/dl/xtb/<ref>.zip   /dl/avo_xtb/...   /dl/avo-xtb/...   /dl/avogadro-xtb/...
+```
+
+Counts are always recorded under the short canonical name (`xtb`), never under
+whichever alias the request happened to use.
+
+Only *separated* prefixes are stripped. A bare `avo` is left alone -- it would
+turn `avogenerators` into `generators` correctly, but also `avocado` into
+`cado`. `avogenerators` still resolves, because the plugin name supplies the
+short form independently.
+
+Repo-derived aliases are registered in a second pass and never overwrite a
+name-derived key, so index order cannot decide which plugin claims a contested
+alias. Across the 28 repositories currently in `repositories.toml` this yields
+59 aliases with no ambiguity; `scripts/` has no checker for this yet, so it is
+worth re-running that audit if a plugin is ever added whose repo name collides
+with another plugin's short name.
+
+## What is stored
+
+One row per `(plugin, ref, day, client)` with a counter. No IP addresses, no
+user agent strings, no per-request rows. `client` is a coarse bucket derived
+from the user agent: `avogadro` for the package manager, `bot` for obvious
+crawlers, `other` for everything else. Only `avogadro` counts as an install.
+
+## Safety properties
+
+- The plugin -> repository map is built from the published index, so the Worker
+  can only redirect to a repository already listed there. It is not an open
+  redirect.
+- Refs are restricted to `[A-Za-z0-9._-]` with no slashes and no `..`, so a
+  crafted ref cannot escape the `/archive/` path.
+- A D1 write failure is logged and swallowed. Stats must never cost an install.
+- If the index is unreachable the fetch is retried once, then falls back to the
+  in-memory copy, then to the last good copy in the `index_cache` table. A cold
+  isolate has no in-memory copy, so without the D1 fallback a single hiccup
+  fetching `plugins2.json` would turn into a failed install.
+- The D1 binding is read as either `DB` or `avogadro_plugin_downloads`, since
+  `wrangler d1 create` suggests a binding named after the database. A mismatch
+  would otherwise leave downloads working while `/stats` returned a bare 500.
+
+## Local testing
+
+```sh
+npx wrangler d1 execute avogadro-plugin-downloads --local --file=./schema.sql
+npx wrangler dev
+./smoke-test.sh          # in another terminal
+```
+
+`smoke-test.sh` checks the redirect target, the name alias, rejection of unknown
+plugins and traversal refs, and that counting excludes HEAD requests and browser
+traffic. It is repeatable -- it baselines the counter first.
+
+To exercise the outage path, point the Worker at an index that is not there and
+confirm downloads still resolve from the D1 fallback:
+
+```sh
+npx wrangler dev --var INDEX_URL:http://127.0.0.1:9/plugins2.json
+```
+
+To inspect the local database directly:
+
+```sh
+npx wrangler d1 execute avogadro-plugin-downloads --local \
+  --command "SELECT * FROM downloads ORDER BY day DESC LIMIT 20;"
+```
+
+## Deploying
+
+`avogadro.cc` is already on Cloudflare nameservers, so the zone is in the
+account and no DNS record has to be created by hand.
+
+**1. Authenticate.** Opens a browser for OAuth:
+
+```sh
+npx wrangler login
+npx wrangler whoami          # confirm the right account, if you have several
+```
+
+**2. Create the database** and copy the printed `database_id` into
+`wrangler.toml`, replacing `local-testing-placeholder`:
+
+```sh
+npx wrangler d1 create avogadro-plugin-downloads
+```
+
+**3. Create the table** in the remote database. `--local` and `--remote` are
+separate databases; the local one used for testing is not touched by deploys:
+
+```sh
+npx wrangler d1 execute avogadro-plugin-downloads --remote --file=./schema.sql
+```
+
+**4. Deploy.** This prints a `*.workers.dev` URL:
+
+```sh
+npx wrangler deploy
+```
+
+**5. Test against the deployed Worker** before wiring up the domain:
+
+```sh
+./smoke-test.sh https://avogadro-plugin-downloads.<subdomain>.workers.dev
+```
+
+Note that this writes real rows into the production database. To clear them:
+
+```sh
+npx wrangler d1 execute avogadro-plugin-downloads --remote \
+  --command "DELETE FROM downloads;"
+```
+
+**6. Attach the domain.** Uncomment the `[[routes]]` block in `wrangler.toml`
+and `npx wrangler deploy` again. Cloudflare creates the `plugins.avogadro.cc`
+DNS record and its certificate automatically. Issuance usually takes under a
+minute; until it completes the hostname may serve a TLS error.
+
+Note that the `workers.dev` URL stops serving once `[[routes]]` is configured:
+wrangler disables the subdomain unless `workers_dev = true` is set explicitly.
+After this step `plugins.avogadro.cc` is the only way in, so test against the
+`workers.dev` URL *before* attaching the domain, not after.
+
+### Rollback
+
+`npx wrangler deployments list` and `npx wrangler rollback [id]`. Deleting the
+route is a config change plus a redeploy; the D1 data survives both.
+
+### Cost
+
+Well inside the free tier at plugin-index volume -- one Worker request and one
+row written per install. Check the current numbers at
+[Workers limits](https://developers.cloudflare.com/workers/platform/limits/) and
+[D1 limits](https://developers.cloudflare.com/d1/platform/limits/) before
+assuming headroom, since the free-tier daily caps do change.
+
+### What is safe to commit
+
+`wrangler.toml` is committed deliberately. `database_id` and `database_name`
+are identifiers, not credentials: reaching that database still requires an API
+token scoped to the Cloudflare account. The same goes for `account_id` if it is
+ever added here.
+
+Never commit:
+
+- Cloudflare API tokens. CI deploys read `CLOUDFLARE_API_TOKEN` from a GitHub
+  Actions secret.
+- `.dev.vars`, which holds local secret vars for `wrangler dev`.
+
+Values set with `wrangler secret put` live in Cloudflare and never touch the
+repo, and the OAuth token from `wrangler login` is stored in `~/.config/` rather
+than in the project.
+
+One consequence of committing `database_id`: a fork that runs `wrangler deploy`
+targets a database id its account cannot reach, so the deploy fails with a
+permissions error. That is a mildly confusing first run for a contributor, not
+a way into this database.
+
+### Docs
+
+- [Workers: get started](https://developers.cloudflare.com/workers/get-started/guide/)
+- [D1: get started](https://developers.cloudflare.com/d1/get-started/)
+- [Custom domains for Workers](https://developers.cloudflare.com/workers/configuration/routing/custom-domains/)
+- [Wrangler commands](https://developers.cloudflare.com/workers/wrangler/commands/)
+
+## Clients must send a User-Agent
+
+Cloudflare answers the default `Python-urllib/...` agent with a 403. Anything
+talking to this Worker needs to identify itself: `generate_index.py` sends
+`avogadro-plugin-index/...`, and Avogadro itself sends
+`Avogadro/2.0 PackageManager`, which is also what marks a request as an install
+rather than incidental traffic.
+
+## Notes
+
+- Redirecting straight to `codeload.github.com/<owner>/<repo>/zip/<ref>` would
+  save one hop, but the `github.com/archive/<ref>.zip` form is what the index
+  uses today and is correct for both commit SHAs and tags. Not worth the risk.
+- `handleRedirect()` in `packagemanagerdialog.cpp` follows redirects with no hop
+  limit. That is fine for this two-hop chain, but a misconfigured redirect loop
+  would spin forever. Worth a counter there independently of this Worker.

--- a/worker/README.md
+++ b/worker/README.md
@@ -27,7 +27,7 @@ handles 301/302/307/308 explicitly.
 | `GET /stats/<plugin>` | One plugin, plus a daily series |
 | `GET /health` | Liveness probe |
 
-`/stats` accepts `?days=` (default 30) and `?client=avogadro\|bot\|other\|all`
+`/stats` accepts `?days=` (default 180) and `?client=avogadro\|bot\|other\|all`
 (default `avogadro`).
 
 ### Plugin names
@@ -121,8 +121,9 @@ npx wrangler login
 npx wrangler whoami          # confirm the right account, if you have several
 ```
 
-**2. Create the database** and copy the printed `database_id` into
-`wrangler.toml`, replacing `local-testing-placeholder`:
+**2. Create the database.** `wrangler.toml` already carries the `database_id`
+of the deployed instance, so this step is only needed when standing up a fresh
+one, in which case put the printed id in `wrangler.toml`:
 
 ```sh
 npx wrangler d1 create avogadro-plugin-downloads
@@ -154,15 +155,15 @@ npx wrangler d1 execute avogadro-plugin-downloads --remote \
   --command "DELETE FROM downloads;"
 ```
 
-**6. Attach the domain.** Uncomment the `[[routes]]` block in `wrangler.toml`
-and `npx wrangler deploy` again. Cloudflare creates the `plugins.avogadro.cc`
-DNS record and its certificate automatically. Issuance usually takes under a
-minute; until it completes the hostname may serve a TLS error.
+The `[[routes]]` block is already active in `wrangler.toml`, so step 4 serves
+on `plugins.avogadro.cc` directly. Cloudflare created the DNS record and its
+certificate when the route was first deployed.
 
-Note that the `workers.dev` URL stops serving once `[[routes]]` is configured:
-wrangler disables the subdomain unless `workers_dev = true` is set explicitly.
-After this step `plugins.avogadro.cc` is the only way in, so test against the
-`workers.dev` URL *before* attaching the domain, not after.
+That also means the `workers.dev` URL does **not** serve: wrangler disables the
+subdomain whenever a route is configured, unless `workers_dev = true` is set.
+To get a URL for testing that is not the live domain, comment the `[[routes]]`
+block out for that deploy, or set `workers_dev = true` alongside it. Step 5 then
+has somewhere to point that is not production.
 
 ### Rollback
 

--- a/worker/schema.sql
+++ b/worker/schema.sql
@@ -1,0 +1,30 @@
+-- Download counters for the Avogadro plugin index.
+--
+-- One row per (plugin, ref, day, client). Daily granularity keeps the table
+-- small -- ~30 plugins x ~365 days is a few tens of thousands of rows a year --
+-- while still supporting both lifetime totals and rolling windows.
+--
+-- No IP addresses, no user agent strings, no per-request rows: `client` is a
+-- coarse bucket only.
+
+CREATE TABLE IF NOT EXISTS downloads (
+  plugin TEXT NOT NULL,     -- short plugin name, e.g. "aimnet2"
+  ref    TEXT NOT NULL,     -- commit SHA or release tag that was fetched
+  day    TEXT NOT NULL,     -- UTC date, YYYY-MM-DD
+  client TEXT NOT NULL,     -- 'avogadro' | 'bot' | 'other'
+  count  INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (plugin, ref, day, client)
+) WITHOUT ROWID;
+
+-- Rolling-window queries filter on day first.
+CREATE INDEX IF NOT EXISTS idx_downloads_day ON downloads (day);
+
+-- Last known good copy of the plugin index.
+--
+-- A cold isolate has no in-memory copy, so without this a transient failure
+-- fetching plugins2.json turns into a failed plugin install. Single row.
+CREATE TABLE IF NOT EXISTS index_cache (
+  id         INTEGER PRIMARY KEY CHECK (id = 1),
+  body       TEXT NOT NULL,
+  fetched_at TEXT NOT NULL
+);

--- a/worker/smoke-test.sh
+++ b/worker/smoke-test.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Smoke test against a running `wrangler dev` (default http://localhost:8787).
+#
+#   Terminal 1:  wrangler d1 execute avogadro-plugin-downloads --local --file=./schema.sql
+#                wrangler dev
+#   Terminal 2:  ./smoke-test.sh
+set -euo pipefail
+
+BASE="${1:-http://localhost:8787}"
+UA="Avogadro/2.0 PackageManager"
+SHA="12a58630dde5b7184dfafd97e67e0022c49f7a09"
+
+pass() { printf '  \033[32mok\033[0m   %s\n' "$1"; }
+fail() { printf '  \033[31mFAIL\033[0m %s\n' "$1"; exit 1; }
+
+echo "==> health"
+curl -fsS "$BASE/health" >/dev/null && pass "responds"
+
+echo "==> redirect for a known plugin"
+loc=$(curl -sS -o /dev/null -D - -H "User-Agent: $UA" \
+  "$BASE/dl/generators/$SHA.zip" | tr -d '\r' | awk 'tolower($1)=="location:"{print $2}')
+[ "$loc" = "https://github.com/OpenChemistry/avogenerators/archive/$SHA.zip" ] \
+  && pass "$loc" || fail "unexpected Location: ${loc:-none}"
+
+echo "==> full-name alias resolves to the same repo"
+loc2=$(curl -sS -o /dev/null -D - -H "User-Agent: $UA" \
+  "$BASE/dl/avogadro-generators/$SHA.zip" | tr -d '\r' | awk 'tolower($1)=="location:"{print $2}')
+[ "$loc2" = "$loc" ] && pass "alias matches" || fail "alias gave ${loc2:-none}"
+
+echo "==> repo-name aliases resolve (repo name != plugin name)"
+# avogadro-xtb lives in matterhorn103/avo_xtb, avogadro-generators in avogenerators.
+for alias in xtb avo_xtb avo-xtb avogadro-xtb; do
+  loc=$(curl -sS -o /dev/null -D - -H "User-Agent: $UA" \
+    "$BASE/dl/$alias/HEAD.zip" | tr -d '\r' | awk 'tolower($1)=="location:"{print $2}')
+  [ "$loc" = "https://github.com/matterhorn103/avo_xtb/archive/HEAD.zip" ] \
+    && pass "$alias" || fail "$alias gave ${loc:-none}"
+done
+loc=$(curl -sS -o /dev/null -D - -H "User-Agent: $UA" \
+  "$BASE/dl/avogenerators/HEAD.zip" | tr -d '\r' | awk 'tolower($1)=="location:"{print $2}')
+[ "$loc" = "https://github.com/OpenChemistry/avogenerators/archive/HEAD.zip" ] \
+  && pass "avogenerators" || fail "avogenerators gave ${loc:-none}"
+
+echo "==> aliases all count into one bucket"
+base=$(curl -sS "$BASE/stats/xtb" | grep -o '"total": *[0-9]*' | grep -o '[0-9]*')
+[ "$base" = "4" ] && pass "4 alias hits landed under 'xtb'" \
+  || fail "expected 4 under 'xtb', got $base"
+curl -sS "$BASE/stats" | grep -q '"avo-xtb"\|"avo_xtb"\|"avogadro-xtb"' \
+  && fail "an alias leaked its own bucket" || pass "no alias buckets"
+
+echo "==> unknown plugin is rejected"
+code=$(curl -sS -o /dev/null -w '%{http_code}' -H "User-Agent: $UA" "$BASE/dl/not-a-plugin/$SHA.zip")
+[ "$code" = "404" ] && pass "404" || fail "expected 404, got $code"
+
+echo "==> traversal ref is rejected"
+code=$(curl -sS -o /dev/null -w '%{http_code}' -H "User-Agent: $UA" "$BASE/dl/generators/..%2f..%2fevil.zip")
+[ "$code" = "400" ] || [ "$code" = "404" ] && pass "$code" || fail "expected 400/404, got $code"
+
+echo "==> counting"
+# Baseline, so the test is repeatable against a database that already has rows.
+before=$(curl -sS "$BASE/stats/generators" | grep -o '"total": *[0-9]*' | grep -o '[0-9]*')
+for _ in 1 2 3; do
+  curl -sS -o /dev/null -H "User-Agent: $UA" "$BASE/dl/generators/$SHA.zip"
+done
+curl -sS -o /dev/null -H "User-Agent: $UA" "$BASE/dl/avogadro-generators/$SHA.zip"  # alias
+curl -sS -o /dev/null -H "User-Agent: Mozilla/5.0" "$BASE/dl/generators/$SHA.zip"   # not an install
+curl -sS -o /dev/null -I -H "User-Agent: $UA" "$BASE/dl/generators/$SHA.zip"        # HEAD, must not count
+sleep 1
+
+after=$(curl -sS "$BASE/stats/generators" | grep -o '"total": *[0-9]*' | grep -o '[0-9]*')
+delta=$(( after - before ))
+# 3 loops + 1 alias. The Mozilla request is 'other', the HEAD counts nowhere.
+[ "$delta" = "4" ] && pass "counted 4 installs (alias folded in, HEAD and browser excluded)" \
+  || fail "expected delta 4, got $delta (before=$before after=$after)"
+
+echo "==> alias does not create a second bucket"
+curl -sS "$BASE/stats" | grep -q '"avogadro-generators"' \
+  && fail "alias leaked a separate 'avogadro-generators' key" \
+  || pass "single canonical key"
+
+echo "==> non-install traffic is still recorded separately"
+all=$(curl -sS "$BASE/stats/generators?client=all" | grep -o '"total": *[0-9]*' | grep -o '[0-9]*')
+[ "$all" -gt "$after" ] && pass "client=all ($all) exceeds installs ($after)" \
+  || fail "expected client=all to exceed the install count"
+
+echo
+echo "All checks passed."

--- a/worker/smoke-test.sh
+++ b/worker/smoke-test.sh
@@ -13,6 +13,13 @@ SHA="12a58630dde5b7184dfafd97e67e0022c49f7a09"
 pass() { printf '  \033[32mok\033[0m   %s\n' "$1"; }
 fail() { printf '  \033[31mFAIL\033[0m %s\n' "$1"; exit 1; }
 
+# Lifetime install count for one plugin. Every count assertion below is a delta
+# against this, so the test is repeatable against a database that already has
+# rows -- which production always does.
+total() {
+  curl -sS "$BASE/stats/$1" | grep -o '"total": *[0-9]*' | grep -o '[0-9]*'
+}
+
 echo "==> health"
 curl -fsS "$BASE/health" >/dev/null && pass "responds"
 
@@ -29,6 +36,7 @@ loc2=$(curl -sS -o /dev/null -D - -H "User-Agent: $UA" \
 
 echo "==> repo-name aliases resolve (repo name != plugin name)"
 # avogadro-xtb lives in matterhorn103/avo_xtb, avogadro-generators in avogenerators.
+xtb_before=$(total xtb)
 for alias in xtb avo_xtb avo-xtb avogadro-xtb; do
   loc=$(curl -sS -o /dev/null -D - -H "User-Agent: $UA" \
     "$BASE/dl/$alias/HEAD.zip" | tr -d '\r' | awk 'tolower($1)=="location:"{print $2}')
@@ -41,9 +49,10 @@ loc=$(curl -sS -o /dev/null -D - -H "User-Agent: $UA" \
   && pass "avogenerators" || fail "avogenerators gave ${loc:-none}"
 
 echo "==> aliases all count into one bucket"
-base=$(curl -sS "$BASE/stats/xtb" | grep -o '"total": *[0-9]*' | grep -o '[0-9]*')
-[ "$base" = "4" ] && pass "4 alias hits landed under 'xtb'" \
-  || fail "expected 4 under 'xtb', got $base"
+sleep 1  # counts are written after the response, in waitUntil
+xtb_delta=$(( $(total xtb) - xtb_before ))
+[ "$xtb_delta" = "4" ] && pass "4 alias hits landed under 'xtb'" \
+  || fail "expected 4 new under 'xtb', got $xtb_delta"
 curl -sS "$BASE/stats" | grep -q '"avo-xtb"\|"avo_xtb"\|"avogadro-xtb"' \
   && fail "an alias leaked its own bucket" || pass "no alias buckets"
 
@@ -56,8 +65,7 @@ code=$(curl -sS -o /dev/null -w '%{http_code}' -H "User-Agent: $UA" "$BASE/dl/ge
 [ "$code" = "400" ] || [ "$code" = "404" ] && pass "$code" || fail "expected 400/404, got $code"
 
 echo "==> counting"
-# Baseline, so the test is repeatable against a database that already has rows.
-before=$(curl -sS "$BASE/stats/generators" | grep -o '"total": *[0-9]*' | grep -o '[0-9]*')
+before=$(total generators)
 for _ in 1 2 3; do
   curl -sS -o /dev/null -H "User-Agent: $UA" "$BASE/dl/generators/$SHA.zip"
 done
@@ -66,7 +74,7 @@ curl -sS -o /dev/null -H "User-Agent: Mozilla/5.0" "$BASE/dl/generators/$SHA.zip
 curl -sS -o /dev/null -I -H "User-Agent: $UA" "$BASE/dl/generators/$SHA.zip"        # HEAD, must not count
 sleep 1
 
-after=$(curl -sS "$BASE/stats/generators" | grep -o '"total": *[0-9]*' | grep -o '[0-9]*')
+after=$(total generators)
 delta=$(( after - before ))
 # 3 loops + 1 alias. The Mozilla request is 'other', the HEAD counts nowhere.
 [ "$delta" = "4" ] && pass "counted 4 installs (alias folded in, HEAD and browser excluded)" \

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -1,0 +1,377 @@
+/**
+ * Download counter for the Avogadro plugin index.
+ *
+ * Routes:
+ *   GET /dl/<plugin>/<ref>.zip   count the request, 302 to the GitHub archive
+ *   GET /stats                   per-plugin totals as JSON
+ *   GET /stats/<plugin>          one plugin, plus its daily series
+ *   GET /health                  liveness probe
+ *
+ * The plugin -> repository mapping comes from the published index, so this
+ * Worker can only ever redirect to a repository that is already in the index.
+ */
+
+const DEFAULT_INDEX_URL = 'https://avogadro.cc/plugins2.json';
+const INDEX_TTL_MS = 10 * 60 * 1000;
+const DEFAULT_WINDOW_DAYS = 30;
+
+// Refs are commit SHAs or release tags. Deliberately strict: no slashes, so a
+// crafted ref cannot walk out of the /archive/ path into another repository.
+const REF_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,99}$/;
+const PLUGIN_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,99}$/;
+const DL_RE = /^\/dl\/([A-Za-z0-9._-]+)\/([A-Za-z0-9._-]+)\.zip$/;
+const BOT_RE = /bot|crawl|spider|slurp|curl|wget|preview|monitor|scan/i;
+
+// Module-global, so it survives between requests on a warm isolate.
+let indexCache = { at: 0, map: null };
+
+export default {
+  async fetch(request, env, ctx) {
+    const url = new URL(request.url);
+    const path = url.pathname.length > 1 ? url.pathname.replace(/\/+$/, '') : '/';
+
+    if (request.method !== 'GET' && request.method !== 'HEAD') {
+      return json({ error: 'method not allowed' }, 405);
+    }
+
+    try {
+      if (path === '/health') {
+        return json({ ok: true });
+      }
+      if (path === '/stats') {
+        return await handleStats(url, env, null, ctx);
+      }
+      if (path.startsWith('/stats/')) {
+        return await handleStats(url, env, path.slice('/stats/'.length), ctx);
+      }
+      if (path.startsWith('/dl/')) {
+        return await handleDownload(request, path, env, ctx);
+      }
+    } catch (err) {
+      console.error('unhandled error', err);
+      return json({ error: 'internal error' }, 500);
+    }
+
+    return json({ error: 'not found' }, 404);
+  },
+};
+
+// --- downloads -------------------------------------------------------------
+
+async function handleDownload(request, path, env, ctx) {
+  const match = DL_RE.exec(path);
+  if (!match) {
+    return json({ error: 'expected /dl/<plugin>/<ref>.zip' }, 400);
+  }
+
+  const [, plugin, ref] = match;
+  if (!PLUGIN_RE.test(plugin) || !validRef(ref)) {
+    return json({ error: 'invalid plugin or ref' }, 400);
+  }
+
+  const repos = await pluginRepoMap(env, ctx);
+  const entry = repos.get(normalizeName(plugin));
+  if (!entry) {
+    return json({ error: `unknown plugin '${plugin}'` }, 404);
+  }
+
+  const target = `https://github.com/${entry.slug}/archive/${ref}.zip`;
+
+  // HEAD requests are probes, not installs.
+  if (request.method === 'GET') {
+    const client = classifyClient(request.headers.get('user-agent'));
+    // Count under the canonical short name, so that requests for `generators`
+    // and `avogadro-generators` land in one bucket rather than two.
+    ctx.waitUntil(record(env, entry.key, ref, client));
+  }
+
+  // 302 rather than 301, and no-store, so that no intermediary caches the hop
+  // and silently swallows future counts.
+  return new Response(null, {
+    status: 302,
+    headers: { Location: target, 'Cache-Control': 'no-store' },
+  });
+}
+
+/**
+ * The D1 handle, under either binding name. `wrangler d1 create` suggests a
+ * binding named after the database, so both spellings are in circulation and
+ * a mismatch is otherwise a silent 500.
+ */
+function database(env) {
+  return env.DB ?? env.avogadro_plugin_downloads ?? null;
+}
+
+async function record(env, plugin, ref, client) {
+  const db = database(env);
+  if (!db) {
+    console.error('no D1 binding; check `binding` in wrangler.toml');
+    return;
+  }
+  const day = new Date().toISOString().slice(0, 10);
+  try {
+    await db.prepare(
+      `INSERT INTO downloads (plugin, ref, day, client, count)
+       VALUES (?1, ?2, ?3, ?4, 1)
+       ON CONFLICT (plugin, ref, day, client)
+       DO UPDATE SET count = count + 1`
+    )
+      .bind(plugin, ref, day, client)
+      .run();
+  } catch (err) {
+    // A stats failure must never cost somebody a plugin install.
+    console.error('record failed', err);
+  }
+}
+
+function validRef(ref) {
+  return REF_RE.test(ref) && !ref.includes('..');
+}
+
+function classifyClient(userAgent) {
+  if (!userAgent) return 'other';
+  if (userAgent.startsWith('Avogadro/')) return 'avogadro';
+  if (BOT_RE.test(userAgent)) return 'bot';
+  return 'other';
+}
+
+// --- stats -----------------------------------------------------------------
+
+async function handleStats(url, env, plugin, ctx) {
+  const days = clampInt(url.searchParams.get('days'), DEFAULT_WINDOW_DAYS, 1, 3650);
+  const client = url.searchParams.get('client') || 'avogadro';
+  if (!['avogadro', 'bot', 'other', 'all'].includes(client)) {
+    return json({ error: `invalid client '${client}'` }, 400);
+  }
+  const cutoff = new Date(Date.now() - days * 86400000).toISOString().slice(0, 10);
+
+  const db = database(env);
+  if (!db) {
+    // Say which knob is wrong rather than a bare 500. Downloads keep working
+    // when this is misconfigured, so stats are where it first shows up.
+    return json({ error: 'no D1 binding configured' }, 503);
+  }
+
+  const body = {
+    generated: new Date().toISOString(),
+    window_days: days,
+    client,
+  };
+
+  if (plugin) {
+    if (!PLUGIN_RE.test(plugin)) {
+      return json({ error: 'invalid plugin' }, 400);
+    }
+    // Accept any alias here too, so `/stats/avo_xtb` and `/stats/xtb` agree.
+    // An unrecognised name falls through unchanged rather than 404ing, so that
+    // rows for a plugin since removed from the index stay queryable.
+    const repos = await pluginRepoMap(env, ctx);
+    plugin = repos.get(normalizeName(plugin))?.key ?? plugin;
+
+    const totals = await db.prepare(
+      `SELECT SUM(count) AS total,
+              SUM(CASE WHEN day >= ?2 THEN count ELSE 0 END) AS recent
+       FROM downloads
+       WHERE plugin = ?1 AND (?3 = 'all' OR client = ?3)`
+    )
+      .bind(plugin, cutoff, client)
+      .first();
+
+    const daily = await db.prepare(
+      `SELECT day, SUM(count) AS count
+       FROM downloads
+       WHERE plugin = ?1 AND day >= ?2 AND (?3 = 'all' OR client = ?3)
+       GROUP BY day
+       ORDER BY day`
+    )
+      .bind(plugin, cutoff, client)
+      .all();
+
+    body.plugin = plugin;
+    body.total = totals?.total ?? 0;
+    body.recent = totals?.recent ?? 0;
+    body.daily = daily.results ?? [];
+    return json(body, 200, { 'Cache-Control': 'public, max-age=300' });
+  }
+
+  const rows = await db.prepare(
+    `SELECT plugin,
+            SUM(count) AS total,
+            SUM(CASE WHEN day >= ?1 THEN count ELSE 0 END) AS recent
+     FROM downloads
+     WHERE (?2 = 'all' OR client = ?2)
+     GROUP BY plugin
+     ORDER BY plugin`
+  )
+    .bind(cutoff, client)
+    .all();
+
+  body.plugins = {};
+  for (const row of rows.results ?? []) {
+    body.plugins[row.plugin] = { total: row.total, recent: row.recent };
+  }
+  return json(body, 200, { 'Cache-Control': 'public, max-age=300' });
+}
+
+function clampInt(raw, fallback, min, max) {
+  const n = Number.parseInt(raw ?? '', 10);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.min(max, Math.max(min, n));
+}
+
+// --- plugin index ----------------------------------------------------------
+
+/**
+ * Map of accepted plugin name -> {key, slug}, where `key` is the canonical
+ * short name used for counting and `slug` is `owner/repo`. Both the short and
+ * the full `avogadro-` prefixed name are accepted as lookup keys.
+ */
+async function pluginRepoMap(env, ctx) {
+  const now = Date.now();
+  if (indexCache.map && now - indexCache.at < INDEX_TTL_MS) {
+    return indexCache.map;
+  }
+
+  const indexUrl = env.INDEX_URL || DEFAULT_INDEX_URL;
+  let entries = null;
+  let body = null;
+
+  // One retry: most blips are a single request, and a cold isolate has no
+  // in-memory copy to fall back on.
+  for (let attempt = 0; attempt < 2 && entries === null; attempt++) {
+    try {
+      if (attempt > 0) await sleep(150);
+      const res = await fetch(indexUrl, {
+        cf: { cacheTtl: 600, cacheEverything: true },
+      });
+      if (!res.ok) throw new Error(`status ${res.status}`);
+      body = await res.text();
+      entries = JSON.parse(body);
+    } catch (err) {
+      console.error(`index fetch failed (attempt ${attempt + 1})`, err);
+    }
+  }
+
+  if (entries === null) {
+    // Serve a stale allowlist rather than break installs while avogadro.cc is
+    // having a bad day. In-memory first, then the last good copy in D1, which
+    // is all a cold isolate has.
+    if (indexCache.map) return indexCache.map;
+    const stored = await loadStoredIndex(env);
+    if (stored) {
+      entries = stored;
+      body = null; // nothing new to persist
+    } else {
+      throw new Error('plugin index unavailable and no cached copy');
+    }
+  } else if (body !== null) {
+    ctx?.waitUntil?.(storeIndex(env, body));
+  }
+
+  const valid = (Array.isArray(entries) ? entries : [])
+    .map((entry) => ({ name: entry?.name, slug: repoSlug(entry?.git?.repo) }))
+    .filter((e) => typeof e.name === 'string' && e.slug);
+
+  const map = new Map();
+
+  // First pass: keys derived from the plugin name, which the index generator
+  // guarantees is `avogadro-<something>`. These are authoritative.
+  for (const { name, slug } of valid) {
+    const key = stripPrefix(normalizeName(name));
+    map.set(normalizeName(name), { key, slug });
+    map.set(key, { key, slug });
+  }
+
+  // Second pass: keys derived from the repository name, which does not have to
+  // match the plugin name -- `avogadro-xtb` lives in `avo_xtb`, and
+  // `avogadro-generators` in `avogenerators`. A repo-derived alias must never
+  // shadow a name-derived key, hence the separate pass: index order should not
+  // decide who wins.
+  for (const { name, slug } of valid) {
+    const key = stripPrefix(normalizeName(name));
+    const repo = normalizeName(slug.split('/')[1]);
+    for (const alias of [repo, stripPrefix(repo)]) {
+      if (!map.has(alias)) map.set(alias, { key, slug });
+    }
+  }
+
+  indexCache = { at: now, map };
+  return map;
+}
+
+/** Persist the last good index so a cold isolate has something to fall back on. */
+async function storeIndex(env, body) {
+  const db = database(env);
+  if (!db) return;
+  try {
+    await db
+      .prepare(
+        `INSERT INTO index_cache (id, body, fetched_at) VALUES (1, ?1, ?2)
+         ON CONFLICT (id) DO UPDATE SET body = ?1, fetched_at = ?2`
+      )
+      .bind(body, new Date().toISOString())
+      .run();
+  } catch (err) {
+    console.error('index_cache write failed', err);
+  }
+}
+
+async function loadStoredIndex(env) {
+  const db = database(env);
+  if (!db) return null;
+  try {
+    const row = await db.prepare(`SELECT body FROM index_cache WHERE id = 1`).first();
+    if (!row?.body) return null;
+    console.error('serving plugin index from D1 fallback');
+    return JSON.parse(row.body);
+  } catch (err) {
+    console.error('index_cache read failed', err);
+    return null;
+  }
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** PEP 503-style: lowercase, and `-`/`_`/`.` runs collapsed to a single `-`. */
+function normalizeName(name) {
+  return name.toLowerCase().replace(/[-_.]+/g, '-');
+}
+
+/**
+ * Drop a leading `avogadro-` or `avo-` from an already-normalized name.
+ *
+ * Only separated prefixes are stripped. A bare `avo` is left alone: it would
+ * turn `avogenerators` into `generators` correctly but also `avocado` into
+ * `cado`, and the name-derived pass already supplies the short form anyway.
+ */
+function stripPrefix(normalized) {
+  for (const prefix of ['avogadro-', 'avo-']) {
+    if (normalized.startsWith(prefix) && normalized.length > prefix.length) {
+      return normalized.slice(prefix.length);
+    }
+  }
+  return normalized;
+}
+
+function repoSlug(repoUrl) {
+  if (typeof repoUrl !== 'string') return null;
+  const m = /^https:\/\/github\.com\/([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+?)(?:\.git)?\/?$/.exec(
+    repoUrl
+  );
+  return m ? `${m[1]}/${m[2]}` : null;
+}
+
+// --- helpers ---------------------------------------------------------------
+
+function json(body, status = 200, headers = {}) {
+  return new Response(JSON.stringify(body, null, 2), {
+    status,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Access-Control-Allow-Origin': '*',
+      ...headers,
+    },
+  });
+}

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -13,7 +13,9 @@
 
 const DEFAULT_INDEX_URL = 'https://avogadro.cc/plugins2.json';
 const INDEX_TTL_MS = 10 * 60 * 1000;
-const DEFAULT_WINDOW_DAYS = 30;
+// Six months. Wide enough that a lightly installed plugin still shows a
+// non-zero count; worth narrowing as the ecosystem grows.
+const DEFAULT_WINDOW_DAYS = 180;
 
 // Refs are commit SHAs or release tags. Deliberately strict: no slashes, so a
 // crafted ref cannot walk out of the /archive/ path into another repository.
@@ -143,7 +145,11 @@ async function handleStats(url, env, plugin, ctx) {
   if (!['avogadro', 'bot', 'other', 'all'].includes(client)) {
     return json({ error: `invalid client '${client}'` }, 400);
   }
-  const cutoff = new Date(Date.now() - days * 86400000).toISOString().slice(0, 10);
+  // `day >= cutoff` includes both boundary dates, so step back days - 1 to
+  // cover exactly `days` dates counting today.
+  const cutoff = new Date(Date.now() - (days - 1) * 86400000)
+    .toISOString()
+    .slice(0, 10);
 
   const db = database(env);
   if (!db) {

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -1,0 +1,18 @@
+name = "avogadro-plugin-downloads"
+main = "src/index.js"
+compatibility_date = "2026-08-01"
+
+[vars]
+INDEX_URL = "https://avogadro.cc/plugins2.json"
+
+[[d1_databases]]
+binding = "avogadro_plugin_downloads"
+database_name = "avogadro-plugin-downloads"
+database_id = "b45550cb-ee2d-4c79-969f-104ca2ae6f18"
+
+# Uncomment to serve on plugins.avogadro.cc. Cloudflare creates the DNS record
+# and certificate itself, because avogadro.cc is already in this account.
+# A custom domain takes a bare hostname -- no "/*" (that is for zone routes).
+[[routes]]
+pattern = "plugins.avogadro.cc"
+custom_domain = true

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -10,9 +10,11 @@ binding = "avogadro_plugin_downloads"
 database_name = "avogadro-plugin-downloads"
 database_id = "b45550cb-ee2d-4c79-969f-104ca2ae6f18"
 
-# Uncomment to serve on plugins.avogadro.cc. Cloudflare creates the DNS record
-# and certificate itself, because avogadro.cc is already in this account.
+# Served on plugins.avogadro.cc. Cloudflare created the DNS record and the
+# certificate itself, because avogadro.cc is already in this account.
 # A custom domain takes a bare hostname -- no "/*" (that is for zone routes).
+# Note that configuring a route disables the workers.dev subdomain unless
+# `workers_dev = true` is set explicitly.
 [[routes]]
 pattern = "plugins.avogadro.cc"
 custom_domain = true


### PR DESCRIPTION
plugins.avogadro.cc now counts downloads for packages
  via a redirected URL to the GitHub or web source

The index will check for a working domain
- if so, use it a redirect
- count recent downloads

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added download tracking for plugin archives with daily statistics.
  - Added health and JSON statistics endpoints.
  - Added support for canonical plugin URLs, aliases, and validated redirects.
  - Added configurable download-worker options, including strict validation mode.
  - Added a worker service with database-backed counters and cached plugin metadata.

- **Documentation**
  - Added setup, deployment, rollback, testing, and operational guidance.

- **Tests**
  - Added smoke tests covering redirects, counting behavior, validation, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->